### PR TITLE
Fixed bug when playing local files

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -35,6 +35,7 @@ def get_current_track(sp) -> Optional[dict]:
 
 def data_from_track(track: dict, sp) -> dict:
     song_name = track["item"]["name"]
+    # local files do not have IDs
     data = (
         (sp.audio_features(track["item"]["id"])[0] or {}) if track["item"]["id"] else {}
     )

--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -35,7 +35,9 @@ def get_current_track(sp) -> Optional[dict]:
 
 def data_from_track(track: dict, sp) -> dict:
     song_name = track["item"]["name"]
-    data = sp.audio_features(track["item"]["id"])[0] or {}
+    data = (
+        (sp.audio_features(track["item"]["id"])[0] or {}) if track["item"]["id"] else {}
+    )
     data["title"] = song_name
     data["uri"] = track["item"]["uri"]
 


### PR DESCRIPTION
Local files doesn't have `track["item"]["id"]`, so when it tries to get audio_features it passes `None` as track_id, and it causes this exception.
```
An exception occurred: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/home/user/.local/opt/activitywatch/aw-watcher-spotify/aw_watcher_spotify/main.py", line 155, in main
    and last_track_data["uri"] != data_from_track(track, sp)["uri"]
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/opt/activitywatch/aw-watcher-spotify/aw_watcher_spotify/main.py", line 38, in data_from_track
    data = sp.audio_features(track["item"]["id"])[0] or {}
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/.local/opt/activitywatch/aw-watcher-spotify/venv/lib64/python3.12/site-packages/spotipy/client.py", line 1752, in audio_features
    tlist = [self._get_id("track", t) for t in tracks]
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not iterable
```

Added check if `track["item"]["id"]` isn't empty, then get audio_features.
<!-- ELLIPSIS_HIDDEN -->

----

| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 7678bb49e351d6696964c4eb2c79fdcdcab99f2e  | 
|--------|--------|

### Summary:
Fixes bug in `aw_watcher_spotify/main.py` by adding a check for `track["item"]["id"]` before retrieving audio features, preventing errors with local files.

**Key points**:
- Fixes bug in `aw_watcher_spotify/main.py` where local files lack `track["item"]["id"]`.
- Adds conditional check in `data_from_track` function to ensure `track["item"]["id"]` is not `None` before calling `sp.audio_features`.
- Prevents `TypeError` when processing local files without `track_id`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->