### PR TITLE
Fix: Update watcher with api fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This watcher is currently in a early stage of development, please submit PRs if 
 
 Go to [Spotify Developer Dashboard](https://developer.spotify.com/dashboard/applications) and create a new application.
 
-In the app settings, add `http://localhost:8088` in the Redirect URIs section.
+In the app settings, add `http://127.0.0.1:8088` in the Redirect URIs section.
 
 ### Step 1: Install package (using poetry)
 

--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -90,7 +90,11 @@ def print_statusline(msg):
     print_statusline.last_msg = msg
 
 
-def main(args):
+def main():
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument("--testing", action="store_true")
+    argparser.add_argument("--verbose", action="store_true")
+    args = argparser.parse_args()
     setup_logging(
     name="aw-watcher-spotify",
     testing=args.testing,
@@ -98,7 +102,6 @@ def main(args):
     log_stderr=True,
     log_file=True,
     )
-
     config_dir = dirs.get_config_dir("aw-watcher-spotify")
 
     config = load_config()
@@ -188,8 +191,4 @@ def main(args):
 
 
 if __name__ == "__main__":
-    argparser = argparse.ArgumentParser()
-    argparser.add_argument("--testing", action="store_true")
-    argparser.add_argument("--verbose", action="store_true")
-    args = argparser.parse_args()
-    main(args)
+    main()

--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -12,6 +12,7 @@ from requests import ConnectionError
 import spotipy
 import spotipy.util as util
 from spotipy.oauth2 import SpotifyClientCredentials
+from spotipy.exceptions import SpotifyException
 
 from aw_core import dirs
 from aw_core.models import Event
@@ -35,10 +36,10 @@ def get_current_track(sp) -> Optional[dict]:
 
 def data_from_track(track: dict, sp) -> dict:
     song_name = track["item"]["name"]
-    # local files do not have IDs
-    data = (
-        (sp.audio_features(track["item"]["id"])[0] or {}) if track["item"]["id"] else {}
-    )
+    try:
+        data = sp.audio_features(track["item"]["id"])[0] or {}
+    except SpotifyException:
+        data = {}
     data["title"] = song_name
     data["uri"] = track["item"]["uri"]
 
@@ -67,7 +68,7 @@ def auth(username, client_id=None, client_secret=None):
         scope=scope,
         client_id=client_id,
         client_secret=client_secret,
-        redirect_uri="http://localhost:8088",
+        redirect_uri="http://127.0.0.1:8088",
     )
 
     if token:

--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -66,7 +66,7 @@ def auth(username: str, client_id: str, client_secret: str) -> Spotify:
         auth_manager = SpotifyOAuth(
             client_id=client_id,
             client_secret=client_secret,
-            redirect_uri="127.0.0.1:8088",
+            redirect_uri="http://127.0.0.1:8088",
             scope=scope,
             cache_path=f".cache-{username}"
         )


### PR DESCRIPTION
There are two primary things that this does:

1. This fixes the redirect url problem. It changed from having `localhost` be acceptable to needing it to be a loopback url. See https://developer.spotify.com/documentation/web-api/concepts/redirect_uri

2. The `audio_features` api is discontinued by spotify for new webapps. Having the method call be unwrapped with a try except block killed the watcher. This change just wraps the audio_features in a try except block so that people who have old apps that currently have access to the API route can still use it. See below for info about changes to the Spotify Web API:
https://developer.spotify.com/blog/2024-11-27-changes-to-the-web-api

Fixes: #29



<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update redirect URI to loopback and handle deprecated `audio_features` API in `main.py`.
> 
>   - **Behavior**:
>     - Update redirect URI from `http://localhost:8088` to `http://127.0.0.1:8088` in `README.md` and `auth()` in `main.py`.
>     - Wrap `sp.audio_features()` call in `data_from_track()` in a try-except block to handle `SpotifyException` for deprecated API.
>   - **Misc**:
>     - Fixes #29.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-spotify&utm_source=github&utm_medium=referral)<sup> for 3b475b42b3644509f2aa160b7a74345291230c27. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->