### PR TITLE
fix: change redirect_uri to work with new spotify guidelines

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -67,7 +67,7 @@ def auth(username, client_id=None, client_secret=None):
         scope=scope,
         client_id=client_id,
         client_secret=client_secret,
-        redirect_uri="http://localhost:8088",
+        redirect_uri="http://127.0.0.1:8088",
     )
 
     if token:


### PR DESCRIPTION
Changed `redirect_uri` to work with new Spotify guidelines - readme still needs to be updated to reflect the changes.

https://github.com/ActivityWatch/aw-watcher-spotify/issues/31
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `redirect_uri` in `auth()` in `main.py` to comply with new Spotify guidelines.
> 
>   - **Behavior**:
>     - Update `redirect_uri` in `auth()` in `main.py` from `http://localhost:8088` to `http://127.0.0.1:8088` to comply with new Spotify guidelines.
>   - **Documentation**:
>     - README update is pending to reflect this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-spotify&utm_source=github&utm_medium=referral)<sup> for 1da1eae80bf1de3d3593d14dc9bc1605c5fd0ced. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->