### PR TITLE
removed sp.audio_features (deprecated)

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -37,7 +37,7 @@ def data_from_track(track: dict, sp) -> dict:
     song_name = track["item"]["name"]
     # local files do not have IDs
     data = (
-        (sp.audio_features(track["item"]["id"])[0] or {}) if track["item"]["id"] else {}
+        () if track["item"]["id"] else{}
     )
     data["title"] = song_name
     data["uri"] = track["item"]["uri"]


### PR DESCRIPTION
The watcher doesn't run at all while requesting `sp.audio_features` due to the Spotify API changes.

Simply removing this makes it run just fine since the feature seems to be only used to request ``id`` here.

See: https://developer.spotify.com/documentation/web-api/reference/get-audio-features
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove deprecated `sp.audio_features` call in `data_from_track()` to fix watcher errors due to Spotify API changes.
> 
>   - **Behavior**:
>     - Removed deprecated `sp.audio_features` call in `data_from_track()` in `main.py`.
>     - The watcher now runs without errors related to Spotify API changes.
>   - **Misc**:
>     - The `id` was previously requested but is not needed for current functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-spotify&utm_source=github&utm_medium=referral)<sup> for 7f5cb5df20fecf2b29590fcb6d4ca4a3d2f72f5d. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->