### PR TITLE
removed audio_features request (deprecated)

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -37,7 +37,7 @@ def data_from_track(track: dict, sp) -> dict:
     song_name = track["item"]["name"]
     # local files do not have IDs
     data = (
-        (sp.audio_features(track["item"]["id"])[0] or {}) if track["item"]["id"] else {}
+        ({}) if track["item"]["id"] else{}
     )
     data["title"] = song_name
     data["uri"] = track["item"]["uri"]


### PR DESCRIPTION
When requesting audio_features the watcher doesn't run at all since the feature was removed from the Spotify API entirely.

Removing the request makes it run again just fine, it seems the feature was only used to request ``"id"`` specifically.

See: https://developer.spotify.com/documentation/web-api/reference/get-audio-features
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes deprecated `audio_features` API call in `data_from_track()` to ensure watcher runs without errors.
> 
>   - **Behavior**:
>     - Removes call to `sp.audio_features(track["item"]["id"])` in `data_from_track()` in `main.py`.
>     - Ensures watcher runs without errors by not using deprecated Spotify API endpoint.
>   - **Misc**:
>     - Updates logic to handle tracks without using `audio_features`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=ActivityWatch%2Faw-watcher-spotify&utm_source=github&utm_medium=referral)<sup> for 5eeb828eb0472505df3ffba8f21edcd73e6a2cb2. You can [customize](https://app.ellipsis.dev/ActivityWatch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->