### PR TITLE
fix: handle missing popularity field in track data

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -44,7 +44,7 @@ def data_from_track(track: dict, sp) -> dict:
     if track["item"]["type"] == "track":
         artist_name = track["item"]["artists"][0]["name"]
         album_name = track["item"]["album"]["name"]
-        data["popularity"] = track["item"]["popularity"] or -1
+        data["popularity"] = track["item"].get("popularity", -1) or -1
         data["album"] = album_name
         data["artist"] = artist_name
         logging.debug("TRACK: {} - {} ({})".format(song_name, artist_name, album_name))


### PR DESCRIPTION
The Spotify API sometimes omits the `popularity` field from the track object, which causes a `KeyError` crash (see #36).

Switched to `.get("popularity", -1)` so it falls back gracefully instead of crashing the watcher.