### PR TITLE
fix: pass --testing flag to ActivityWatchClient

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -114,8 +114,7 @@ def main():
         )
         sys.exit(1)
 
-    # TODO: Fix --testing flag and set testing as appropriate
-    aw = ActivityWatchClient("aw-watcher-spotify", testing=False)
+    aw = ActivityWatchClient("aw-watcher-spotify", testing=args.testing)
     bucketname = "{}_{}".format(aw.client_name, aw.client_hostname)
     aw.create_bucket(bucketname, "currently-playing", queued=True)
     aw.connect()


### PR DESCRIPTION
The `--testing` flag was parsed by argparse but never actually passed to `ActivityWatchClient` — it was hardcoded to `testing=False`. So running `aw-watcher-spotify --testing` still connected to the production server on port 5600.

Now it uses `args.testing`, same as `setup_logging` already does a few lines above. Matches how other watchers (e.g. aw-watcher-window) handle this.