### PR TITLE
fix: handle missing 'popularity' field in Spotify API response (issue #36)

### DIFF
--- a/aw_watcher_spotify/main.py
+++ b/aw_watcher_spotify/main.py
@@ -44,7 +44,7 @@ def data_from_track(track: dict, sp) -> dict:
     if track["item"]["type"] == "track":
         artist_name = track["item"]["artists"][0]["name"]
         album_name = track["item"]["album"]["name"]
-        data["popularity"] = track["item"]["popularity"] or -1
+        data["popularity"] = track["item"].get("popularity") or -1
         data["album"] = album_name
         data["artist"] = artist_name
         logging.debug("TRACK: {} - {} ({})".format(song_name, artist_name, album_name))


### PR DESCRIPTION
## Summary

Fixes #36

The Spotify API has deprecated the `popularity` field in track responses. When this field is missing from the API response, accessing `track["item"]["popularity"]` raises a `KeyError: 'popularity'`.

## Changes

- Use `.get("popularity")` instead of direct dict access to safely handle the missing field
- Defaults to `-1` when the field is absent (preserving the existing fallback behavior)

## Testing

This is a runtime fix for a Spotify API deprecation. The field was already removed from newer API responses. The fix ensures backward compatibility with both old and new API responses.